### PR TITLE
Fix builder.sh to actually run

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . env.sh
 


### PR DESCRIPTION
The magic interpreter was set to 'sh' which behaves differently from bash, and it seems bash is required.  Fix this.